### PR TITLE
Add utf-8 encoding

### DIFF
--- a/redis.py
+++ b/redis.py
@@ -19,7 +19,7 @@ class RedisDatabase(Database):
         await self.client.execute('SET', key, json.dumps(data))
 
     async def get(self, key):
-        data = await self.client.execute('GET', key)
+        data = await self.client.execute('GET', key, encoding="utf-8")
 
         if data:
             return self.convert_timestamp_to_object(json.loads(data))


### PR DESCRIPTION
I was getting an error from `json.loads` saying `the JSON object must be str, not 'bytes'`. Setting the encoding in the redis query fixed it.